### PR TITLE
Provide GITOSIS_ORIGINAL_USER env variable

### DIFF
--- a/gitosis/serve.py
+++ b/gitosis/serve.py
@@ -210,6 +210,7 @@ class Main(app.App):
             sys.exit(1)
 
         main_log.debug('Serving %s', newcmd)
+        os.environ["GITOSIS_ORIGINAL_USER"] = user
         os.execvp('git', ['git', 'shell', '-c', newcmd])
         main_log.error('Cannot execute git-shell.')
         sys.exit(1)


### PR DESCRIPTION
This PR adds an environment variable GITOSIS_ORIGINAL_USER which contains the user name of the pushing user. (From argv[1] within authorized keys). This variable is required in post-receive hooks that emulate guthub-style webhooks (those need to provide a "pusher" which might be different from a committer).